### PR TITLE
Integrate and orchestrate arithmetic coding for enterprise streaming

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -100,13 +100,17 @@ pub mod motion_estimation;
 pub mod quantization;
 
 // Enterprise architecture and advanced algorithms
+#[path = "src/enterprise_architecture/mod.rs"]
 pub mod enterprise_architecture;
 pub mod advanced_compression_algorithms;
 pub mod biological_modeling_enhancements;
+#[path = "src/afiyah_codec/mod.rs"]
 pub mod afiyah_codec;
 pub mod testing_validation;
 pub mod performance_optimization;
 pub mod bitstream_formatting;
+#[path = "src/arithmetic_coding/mod.rs"]
+pub mod arithmetic_coding;
 
 // Quality metrics system
 pub mod quality_metrics;

--- a/src/enterprise_architecture/mod.rs
+++ b/src/enterprise_architecture/mod.rs
@@ -53,6 +53,7 @@ use tokio::sync::{RwLock, Mutex};
 use serde::{Deserialize, Serialize};
 use anyhow::{Result, anyhow};
 use uuid::Uuid;
+use crate::entropy_coding::{BiologicalEntropyCoder, EntropyCodingConfig, Symbol};
 
 /// Enterprise compression service orchestrator
 pub struct EnterpriseCompressionOrchestrator {
@@ -417,8 +418,12 @@ impl EnterpriseCompressionOrchestrator {
                 Ok(input_data)
             }
             ServiceRole::EntropyCoding => {
-                // Simulate entropy coding
+                // Simulate entropy coding and validate coder health via a tiny probe
                 tokio::time::sleep(Duration::from_millis(5)).await;
+                let mut coder = BiologicalEntropyCoder::new(EntropyCodingConfig::default())
+                    .map_err(|e| anyhow!("entropy coder init failed: {e}"))?;
+                let probe: Vec<Symbol> = vec![Symbol::Luminance(0.0), Symbol::Luminance(1.0)];
+                let _ = coder.encode(&probe).map_err(|e| anyhow!("entropy probe encode failed: {e}"))?;
                 Ok(input_data)
             }
             ServiceRole::TransformCoding => {


### PR DESCRIPTION
Integrate the new `arithmetic_coding` module into `AfiyahCodec` for entropy-coded streams, wire it through `lib.rs`, enhance the orchestrator, and add tests to support enterprise-grade Afiyah stream generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dcb4b48-5b54-4ed3-a27f-69b4bbf5e47d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dcb4b48-5b54-4ed3-a27f-69b4bbf5e47d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

